### PR TITLE
Update ParsedownExtraPlugin.php

### DIFF
--- a/ParsedownExtraPlugin.php
+++ b/ParsedownExtraPlugin.php
@@ -27,7 +27,7 @@ class ParsedownExtraPlugin extends ParsedownExtra {
 
     public $blockCodeAttributes = array();
 
-    public $blockCodeClassFormat = 'language-%s';
+    public $blockCodeClassFormat = '%s';
 
     public $blockCodeHtml = null;
 


### PR DESCRIPTION
Fixed an issue where this caused the prefix "language" to be added twice (with parsedown 1.8 beta 7)