### PR TITLE
feat: adjust requirement to use latest version for parsedown-extra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   "name": "taufik-nurrohman/parsedown-extra-plugin",
   "require": {
     "erusev/parsedown": "^1.8.0@beta",
-    "erusev/parsedown-extra": "0.8.0"
+    "erusev/parsedown-extra": "^0.8.0"
   },
   "support": {
     "docs": "https://github.com/taufik-nurrohman/parsedown-extra-plugin#readme",


### PR DESCRIPTION
To address issue:
- **parsedown-extra** is currently at latest stable **v0.8.1** and **parsedown-extra-plugin**'s composer fixes it to **v0.8.0**